### PR TITLE
添加了设计尺寸的参数

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ npx iconfont-init
   "platforms": "*",
   "use_rpx": true,
   "trim_icon_prefix": "icon",
-  "default_icon_size": 18
+  "default_icon_size": 18,
+  "design_width": 750
 }
 ```
 ### 配置参数说明：
@@ -83,6 +84,9 @@ npx iconfont-init
 
 ### use_rpx
 是否使用[尺寸单位rpx](https://developers.weixin.qq.com/miniprogram/dev/framework/view/wxss.html#%E5%B0%BA%E5%AF%B8%E5%8D%95%E4%BD%8D)还是普通的像素单位`px`。默认值为true，与Taro保持一致的缩放。您也可以设置为false，强制使用`px`
+
+### design_width
+若 `use_rpx: true` 且当前设计图尺寸不为 750 时，可以通过修改这个字段来修改设计尺寸。
 
 ### trim_icon_prefix
 如果你的图标有通用的前缀，而你在使用的时候又不想重复去写，那么可以通过这种配置这个选项把前缀统一去掉。

--- a/scripts/config/iconfont-js.json
+++ b/scripts/config/iconfont-js.json
@@ -3,6 +3,7 @@
   "use_typescript": false,
   "platforms": "*",
   "use_rpx": true,
+  "design_width": 720,
   "save_dir": "./snapshots/iconfont-js",
   "trim_icon_prefix": "icon",
   "default_icon_size": 14

--- a/snapshots/iconfont-js/index.h5.js
+++ b/snapshots/iconfont-js/index.h5.js
@@ -7,7 +7,7 @@ import Icon from './h5';
 const IconFont = (props) => {
   const { name, size, color } = props;
 
-  return <Icon name={name} size={parseFloat(Taro.pxTransform(size, 750))} color={color} />;
+  return <Icon name={name} size={parseFloat(Taro.pxTransform(size, 720))} color={color} />;
 };
 
 IconFont.defaultProps = {

--- a/src/libs/generateUsingComponent.ts
+++ b/src/libs/generateUsingComponent.ts
@@ -2,7 +2,14 @@ import path from 'path';
 import fs from 'fs';
 import { Config } from './getConfig';
 import { getTemplate } from './getTemplate';
-import { replaceIsRpx, replaceNames, replacePlatform, replaceSize, replaceRelativePath } from './replace';
+import {
+  replaceIsRpx,
+  replaceNames,
+  replacePlatform,
+  replaceSize,
+  replaceRelativePath,
+  replaceDesignWidth,
+} from './replace';
 
 export const generateUsingComponent = (config: Config, names: string[], platform?: string) => {
   const saveDir = path.resolve(config.save_dir);
@@ -22,6 +29,12 @@ export const generateUsingComponent = (config: Config, names: string[], platform
 
   iconFile = replaceNames(iconFile, names);
   iconFile = replaceSize(iconFile, config.default_icon_size);
+
+  if(platform === 'h5' && config.use_rpx) {
+    let designWidth = config.design_width || 750
+    iconFile = replaceDesignWidth(iconFile, designWidth);
+  }
+
   iconFile = replaceIsRpx(iconFile, config.use_rpx);
 
   if (platform) {

--- a/src/libs/getConfig.ts
+++ b/src/libs/getConfig.ts
@@ -11,6 +11,7 @@ export interface Config {
   use_typescript: boolean;
   platforms: string[];
   use_rpx: boolean;
+  design_width: string | number;
   trim_icon_prefix: string;
   default_icon_size: number;
 }

--- a/src/libs/iconfont.json
+++ b/src/libs/iconfont.json
@@ -5,5 +5,6 @@
   "platforms": "*",
   "use_rpx": true,
   "trim_icon_prefix": "icon",
-  "default_icon_size": 18
+  "default_icon_size": 18,
+  "design_width":  750
 }

--- a/src/libs/replace.ts
+++ b/src/libs/replace.ts
@@ -18,6 +18,11 @@ export const replaceIsRpx = (content: string, useRpx: boolean) => {
     .replace(/#rpx-0:(.+?):#/g, useRpx ? '' : '$1');
 };
 
+export const replaceDesignWidth = (content: string, designWidth) => {
+  return content
+    .replace(/#designWidth#/g, designWidth)
+};
+
 export const replaceRelativePath = (content: string, saveDir: string) => {
   const relativePath = path.relative(path.resolve('src'), path.resolve(saveDir));
   return content.replace(/#relativePath#/g, relativePath);

--- a/src/templates/index.h5.js.template
+++ b/src/templates/index.h5.js.template
@@ -7,7 +7,7 @@ import Icon from './h5';
 const IconFont = (props) => {
   const { name, size, color } = props;
 
-  return <Icon name={name} size={#rpx-1:parseFloat(Taro.pxTransform(size, 750)):##rpx-0:size:#} color={color} />;
+  return <Icon name={name} size={#rpx-1:parseFloat(Taro.pxTransform(size, #designWidth#)):##rpx-0:size:#} color={color} />;
 };
 
 IconFont.defaultProps = {

--- a/src/templates/index.h5.tsx.template
+++ b/src/templates/index.h5.tsx.template
@@ -14,7 +14,7 @@ interface Props {
 const IconFont: FunctionComponent<Props> = (props) => {
   const { name, size, color } = props;
 
-  return <Icon name={name} size={#rpx-1:parseFloat(Taro.pxTransform(size, 750)):##rpx-0:size:#} color={color} />;
+  return <Icon name={name} size={#rpx-1:parseFloat(Taro.pxTransform(size, #designWidth#)):##rpx-0:size:#} color={color} />;
 };
 
 IconFont.defaultProps = {


### PR DESCRIPTION
首先设计图默认了是 750, 但是 ui 给的不是 750, 这是我修改的起因

再是参数是直接写在了 `iconfont-js.json` 里面  
这个参数在 taro 的 config/index.js 文件下也有, 但是在这个文件里面, 是可以使用 es6 的语法 `import` ,  
当前的node 脚本不支持,那么只能使用在 json 里添加参数了