### PR TITLE
Fix ESLint:  Parsing error: Const declarations require an initializat…

### DIFF
--- a/src/templates/helper.d.ts.template
+++ b/src/templates/helper.d.ts.template
@@ -1,1 +1,1 @@
-export declare const useGlobalIconFont: () => { iconfont: string };
+export declare var useGlobalIconFont: () => { iconfont: string };


### PR DESCRIPTION

决绝 typescript 3.8.2 默认 eslint 规则报错。

ESLint: 
Parsing error: Const declarations require an initialization value