### PR TITLE
✨新功能: 适配vue2/3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 node_modules/
 *.log
-.idea/
 build/
 /iconfont.json
+
+# macOS
 .DS_Store
+
+# IDE
+.idea/
+.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 4、支持自定义颜色
 <br>
 5、支持es6和typescript两种模式
+<br>
+6、支持vue/react（v3.3.0版本以上）
 
 # Step 1
 安装插件
@@ -49,6 +51,7 @@ npx iconfont-init
   "symbol_url": "请参考README.md，复制 http://iconfont.cn 官网提供的JS链接",
   "save_dir": "./src/components/iconfont",
   "use_typescript": false,
+  "lang":"react",
   "platforms": "*",
   "use_rpx": true,
   "trim_icon_prefix": "icon",
@@ -71,6 +74,17 @@ npx iconfont-init
 如果您的项目使用Typescript编写，请设置为true。这个选项将决定生成的图标组件是`.tsx`还是`.js`后缀。
 
 当该值为false时，我们会为您的图标生成`.js`和`.d.ts`两个文件，以便您能享受到最好的开发体验。
+
+### lang
+`v3.3.0`以上版本支持Vue，React。如果您的项目使用Vue编写，请设置为"Vue"。这个选项将决定生成的图标组件是`.jsx/.tsx`还是`.vue`组件。
+
+```json5
+{
+  // 选择你需要的语言
+  // 说明 =>  react: React | vue: Vue
+  "lang": "react" 或 "vue",
+}
+```
 
 ### platforms
 选择需要支持的平台，默认是`*`，意味着所有平台都需要支持（如果有）。如果你只想支持部分平台，也可以设置成数组：
@@ -124,6 +138,9 @@ export default {
 
 # 使用
 在Page中使用图标
+
+React：
+
 ```jsx harmony
 import React, { Component } from 'react';
 import IconFont from '../components/iconfont';
@@ -136,7 +153,20 @@ class App extends Component {
 
 export default App;
 ```
+Vue：
+```vue
+<template>
+	<iconfont name="alipay"></iconfont>
+</template>
+
+<script lang="ts" setup>
+	import Iconfont from "@/components/iconfont/Index.vue";
+</script>
+
+```
+
 更多用法：
+
 ```jsx harmony
 // 原色彩
 <IconFont name="alipay" />

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mkdirp": "^0.5.1",
     "react-iconfont-cli": "2.0.2",
     "react-native-iconfont-cli": "2.2.4",
-    "vue-iconfonts-cli": "^1.0.2",
+    "vue-iconfonts-cli": "^1.0.3",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "mkdirp": "^0.5.1",
     "react-iconfont-cli": "2.0.2",
     "react-native-iconfont-cli": "2.2.4",
-    "vue-iconfonts-cli": "^1.0.2"
+    "vue-iconfonts-cli": "^1.0.2",
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@tarojs/taro": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mkdirp": "^0.5.1",
     "react-iconfont-cli": "2.0.2",
     "react-native-iconfont-cli": "2.2.4",
-    "vue-iconfonts-cli": "^1.0.4",
+    "vue-iconfonts-cli": "^1.0.5",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tarojs/taro": "^3.0.8"
   },
   "dependencies": {
+    "@types/http-proxy": "^1.17.7",
     "colors": "^1.4.0",
     "fs-extra": "^8.1.0",
     "iconfont-parser": "^1.0.0",
@@ -22,7 +23,7 @@
     "mkdirp": "^0.5.1",
     "react-iconfont-cli": "2.0.2",
     "react-native-iconfont-cli": "2.2.4",
-    "tslib": "^2.3.1"
+    "vue-iconfonts-cli": "^1.0.2"
   },
   "devDependencies": {
     "@tarojs/taro": "^3.0.5",
@@ -37,6 +38,8 @@
     "react-native": "^0.65.1",
     "react-native-svg": "^9.9.4",
     "ts-node": "^8.4.1",
-    "typescript": "^3.6.3"
+    "tslib": "^2.3.1",
+    "typescript": "^4.5.3",
+    "vue": "^2.6.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mkdirp": "^0.5.1",
     "react-iconfont-cli": "2.0.2",
     "react-native-iconfont-cli": "2.2.4",
-    "vue-iconfonts-cli": "^1.0.3",
+    "vue-iconfonts-cli": "^1.0.4",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/scripts/config/iconfont-js.json
+++ b/scripts/config/iconfont-js.json
@@ -2,6 +2,7 @@
   "symbol_url": "http://at.alicdn.com/t/font_1373348_ghk94ooopqr.js",
   "use_typescript": false,
   "platforms": "*",
+  "lang": "react",
   "use_rpx": true,
   "design_width": 720,
   "save_dir": "./snapshots/iconfont-js",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -16,6 +16,7 @@ const basePath = path.join(__dirname, '..');
 const miniProgramBasePath = 'node_modules/mini-program-iconfont-cli';
 const reactNativeBasePath = 'node_modules/react-native-iconfont-cli';
 const reactWebBasePath = 'node_modules/react-iconfont-cli';
+const vueWebBasePath = 'node_modules/vue-iconfonts-cli';
 const miniProgramDir = fs.existsSync(path.join(basePath, miniProgramBasePath))
   ? path.join(basePath, miniProgramBasePath)
   : path.resolve(miniProgramBasePath);
@@ -25,9 +26,13 @@ const reactNativeDir = fs.existsSync(path.join(basePath, reactNativeBasePath))
 const reactWebDir = fs.existsSync(path.join(basePath, reactWebBasePath))
   ? path.join(basePath, reactWebBasePath)
   : path.resolve(reactWebBasePath);
+const vueWebDir = fs.existsSync(path.join(basePath, vueWebBasePath))
+  ? path.join(basePath, vueWebBasePath)
+  : path.resolve(vueWebBasePath);
 
 const config = getConfig();
 
+const isVue = config.lang === 'vue';
 fetchXml(config.symbol_url).then((result) => {
   if (!config.platforms.length) {
     console.warn(`\nPlatform is required.\n`);
@@ -75,7 +80,12 @@ fetchXml(config.symbol_url).then((result) => {
         fs.unlinkSync(rnFilePath);
       });
     } else {
-      execFile = execFile.replace(/react-iconfont-cli/, reactWebDir);
+      let langReg = /react-iconfont-cli/;
+      if (isVue) {
+        execFile = 'vue-iconfonts-cli/libs/generateComponent';
+        langReg = /vue-iconfonts-cli/;
+      }
+      execFile = execFile.replace(langReg, isVue ? vueWebDir : reactWebDir);
       require(execFile)[execMethod](result, filterReactWebConfig(config, platform));
 
       // Remove .d.ts files

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -94,8 +94,8 @@ fetchXml(config.symbol_url).then((result) => {
       });
     }
 
-    if (platform === 'h5' && isVue) {
-      platform = 'h5-vue';
+    if (platform && isVue) {
+      platform = platform + '-vue';
     }
 
     generateUsingComponent(config, iconNames, platform);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,7 +8,7 @@ import mkdirp from 'mkdirp';
 import { getConfig } from '../libs/getConfig';
 import { fetchXml } from 'iconfont-parser';
 import { PLATFORM_MAP } from '../libs/maps';
-import { filterMiniProgramConfig, filterReactNativeConfig, filterReactWebConfig } from '../libs/filterConfig';
+import { filterMiniProgramConfig, filterReactNativeConfig, filterH5WebConfig } from '../libs/filterConfig';
 import { generateUsingComponent } from '../libs/generateUsingComponent';
 import { getIconNames } from '../libs/getIconNames';
 
@@ -86,12 +86,16 @@ fetchXml(config.symbol_url).then((result) => {
         langReg = /vue-iconfonts-cli/;
       }
       execFile = execFile.replace(langReg, isVue ? vueWebDir : reactWebDir);
-      require(execFile)[execMethod](result, filterReactWebConfig(config, platform));
+      require(execFile)[execMethod](result, filterH5WebConfig(config, platform));
 
       // Remove .d.ts files
       glob.sync(path.resolve(config.save_dir, platform, '*.d.ts')).map((h5FilePath) => {
         fs.unlinkSync(h5FilePath);
       });
+    }
+
+    if (platform === 'h5' && isVue) {
+      platform = 'h5-vue';
     }
 
     generateUsingComponent(config, iconNames, platform);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -32,7 +32,7 @@ const vueWebDir = fs.existsSync(path.join(basePath, vueWebBasePath))
 
 const config = getConfig();
 
-const isVue = config.lang === 'vue';
+const isVue = config.lang === 'vue' && !config.use_typescript;
 fetchXml(config.symbol_url).then((result) => {
   if (!config.platforms.length) {
     console.warn(`\nPlatform is required.\n`);

--- a/src/libs/filterConfig.ts
+++ b/src/libs/filterConfig.ts
@@ -21,7 +21,7 @@ export const filterReactNativeConfig = (config: Config, platform: string) => {
   };
 };
 
-export const filterReactWebConfig = (config: Config, platform: string) => {
+export const filterH5WebConfig = (config: Config, platform: string) => {
   return {
     symbol_url: config.symbol_url,
     use_typescript: config.use_typescript,

--- a/src/libs/generateUsingComponent.ts
+++ b/src/libs/generateUsingComponent.ts
@@ -54,5 +54,9 @@ export const generateUsingComponent = (config: Config, names: string[], platform
   fs.writeFileSync(path.join(saveDir, 'helper.js'), helperFile);
   fs.writeFileSync(path.join(saveDir, 'helper.d.ts'), getTemplate('helper.d.ts'));
 
+  if (platform === "h5-vue") {
+    platform = "h5";
+  }
+
   fs.writeFileSync(path.join(saveDir, 'index' + (platform ? `.${platform}` : '') + jsxExtension), iconFile);
 };

--- a/src/libs/generateUsingComponent.ts
+++ b/src/libs/generateUsingComponent.ts
@@ -21,7 +21,7 @@ export const generateUsingComponent = (config: Config, names: string[], platform
     if (fs.existsSync(path.join(__dirname, '../templates/index.' + platform + jsxExtension + '.template'))) {
       iconFile = getTemplate('index.' + platform + jsxExtension);
     } else {
-      iconFile = getTemplate('index.platform' + jsxExtension);
+      iconFile = getTemplate(`index.platform${(platform && platform.includes("-vue")) ? "-vue" : ""}` + jsxExtension);
     }
   } else {
     iconFile = getTemplate('index' + jsxExtension);
@@ -30,7 +30,7 @@ export const generateUsingComponent = (config: Config, names: string[], platform
   iconFile = replaceNames(iconFile, names);
   iconFile = replaceSize(iconFile, config.default_icon_size);
 
-  if(platform === 'h5' && config.use_rpx) {
+  if (platform === 'h5' && config.use_rpx) {
     let designWidth = config.design_width || 750
     iconFile = replaceDesignWidth(iconFile, designWidth);
   }
@@ -54,8 +54,8 @@ export const generateUsingComponent = (config: Config, names: string[], platform
   fs.writeFileSync(path.join(saveDir, 'helper.js'), helperFile);
   fs.writeFileSync(path.join(saveDir, 'helper.d.ts'), getTemplate('helper.d.ts'));
 
-  if (platform === "h5-vue") {
-    platform = "h5";
+  if (platform && platform.includes("-vue")) {
+    platform = platform.replace(/-vue/, "");
     fs.writeFileSync(path.join(saveDir, "shims.d.ts"), getTemplate('shims.d.ts'));
   }
 

--- a/src/libs/generateUsingComponent.ts
+++ b/src/libs/generateUsingComponent.ts
@@ -56,6 +56,7 @@ export const generateUsingComponent = (config: Config, names: string[], platform
 
   if (platform === "h5-vue") {
     platform = "h5";
+    fs.writeFileSync(path.join(saveDir, "shims.d.ts"), getTemplate('shims.d.ts'));
   }
 
   fs.writeFileSync(path.join(saveDir, 'index' + (platform ? `.${platform}` : '') + jsxExtension), iconFile);

--- a/src/libs/getConfig.ts
+++ b/src/libs/getConfig.ts
@@ -10,6 +10,7 @@ export interface Config {
   save_dir: string;
   use_typescript: boolean;
   platforms: string[];
+  lang?: "vue" | "react";
   use_rpx: boolean;
   design_width: string | number;
   trim_icon_prefix: string;

--- a/src/libs/iconfont.json
+++ b/src/libs/iconfont.json
@@ -3,6 +3,7 @@
   "save_dir": "./src/components/iconfont",
   "use_typescript": false,
   "platforms": "*",
+  "lang": "vue",
   "use_rpx": true,
   "trim_icon_prefix": "icon",
   "default_icon_size": 18,

--- a/src/libs/replace.ts
+++ b/src/libs/replace.ts
@@ -27,6 +27,6 @@ export const replaceRelativePath = (content: string, saveDir: string) => {
   const relativePath = path
     .relative(path.resolve('src'), path.resolve(saveDir))
     // To resolve the path separator on windows
-    .replace('\\', '/');
+    .replace(/\\/g, '/');
   return content.replace(/#relativePath#/g, relativePath);
 };

--- a/src/templates/index.h5-vue.js.template
+++ b/src/templates/index.h5-vue.js.template
@@ -1,0 +1,3 @@
+import Icon from "./h5/Index.vue";
+
+export default Icon;

--- a/src/templates/index.h5-vue.tsx.template
+++ b/src/templates/index.h5-vue.tsx.template
@@ -1,0 +1,3 @@
+import Icon from "./h5/Index.vue";
+
+export default Icon;

--- a/src/templates/index.platform-vue.js.template
+++ b/src/templates/index.platform-vue.js.template
@@ -1,0 +1,3 @@
+import Icon from "./h5/Index.vue";
+
+export default Icon;

--- a/src/templates/index.platform-vue.tsx.template
+++ b/src/templates/index.platform-vue.tsx.template
@@ -1,0 +1,3 @@
+import Icon from "./h5/Index.vue";
+
+export default Icon;

--- a/src/templates/shims.d.ts.template
+++ b/src/templates/shims.d.ts.template
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+    import { ComponentOptions } from 'vue'
+    const componentOptions: ComponentOptions
+    export default componentOptions
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": ["esnext"],
+    "lib": ["esnext", "es2021.String"],
     "allowJs": false,
     "declaration": true,
     "removeComments": false,
@@ -30,8 +30,5 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "exclude": [
-    "./snapshots/",
-    "./build/"
-  ]
+  "exclude": ["./snapshots/", "./build/"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,6 +1143,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/http-proxy@^1.17.7":
+  version "1.17.7"
+  resolved "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.7.tgz#30ea85cc2c868368352a37f0d0d3581e24834c6f"
+  integrity sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -4379,7 +4386,7 @@ tslib@^1.10.0:
 
 tslib@^2.3.1:
   version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 type-fest@^0.7.1:
@@ -4387,10 +4394,10 @@ type-fest@^0.7.1:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
   integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
-typescript@^3.6.3:
-  version "3.6.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
+  integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
 
 uglify-es@^3.1.9:
   version "3.3.9"
@@ -4530,6 +4537,24 @@ vlq@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
   integrity sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==
+
+vue-iconfonts-cli@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/vue-iconfonts-cli/-/vue-iconfonts-cli-1.0.2.tgz#e126453339a30a01af01121c020f392f1b35b3cc"
+  integrity sha512-/DdcyAifhUMkXWguwd0XE7jbHdQGJ7/xGjISZY8rxt+7FSCUqZ4OauMsS/5Gi3YIqAH/xAMrf8YlGY9Lglb3Lg==
+  dependencies:
+    colors "^1.3.3"
+    glob "^7.1.4"
+    iconfont-parser "^1.0.0"
+    lodash "^4.17.15"
+    minimist "^1.2.5"
+    mkdirp "^0.5.1"
+    tslib "^1.10.0"
+
+vue@^2.6.14:
+  version "2.6.14"
+  resolved "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
+  integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4538,10 +4538,10 @@ vlq@^1.0.0:
   resolved "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
   integrity sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==
 
-vue-iconfonts-cli@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/vue-iconfonts-cli/-/vue-iconfonts-cli-1.0.2.tgz#e126453339a30a01af01121c020f392f1b35b3cc"
-  integrity sha512-/DdcyAifhUMkXWguwd0XE7jbHdQGJ7/xGjISZY8rxt+7FSCUqZ4OauMsS/5Gi3YIqAH/xAMrf8YlGY9Lglb3Lg==
+vue-iconfonts-cli@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/vue-iconfonts-cli/-/vue-iconfonts-cli-1.0.4.tgz#eb60c37dd3481edb2794e8c4b72855b1f7754dc9"
+  integrity sha512-w/3tgiwGyzWCv0QtNMS5dBcRgBEEoxy8tGYS5KVXta7pL88ASQRfqgTlLyokDSXHE/CVxiYmMnMhfqASwg2wpg==
   dependencies:
     colors "^1.3.3"
     glob "^7.1.4"


### PR DESCRIPTION
#39 # feat: 增加vue2/3的支持

- 增加适配：使用"lang":”vue“来指定taro-iconfont-cli生成Vue2/3组件。
- 修复： 
        1.replaceRelativePath方法，使用正则来替换。
        2.tslib开发环境下报错。
        3.http-proxy开发环境下报错。
        4.修复ts下引入vue组件的报错。
        5.修复index.h5.js引入vue模块。


- 增加依赖：
        vue-iconfonts-cli v1.0.2
        vue v2.6.14
        @types/http-proxy v1.17.7

- 升级依赖版本：
         typescript 3.6.3 => typescript 4.5.3 